### PR TITLE
Make script compatible with a venv

### DIFF
--- a/check_user_in_groups.py
+++ b/check_user_in_groups.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from typing import List, Set, Tuple
 
 from ldap3 import Entry, Server, Connection, ALL, SIMPLE


### PR DESCRIPTION
use
```python
#!/usr/bin/env python3
```
instead of:
```python
#!/usr/bin/python3
```
otherwise you can't run it from a virtual env